### PR TITLE
Add testing dependences, files/folders

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,69 @@
+// Karma configuration
+// Generated on Mon Jan 30 2017 19:48:27 GMT-0800 (Pacific Standard Time)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'test/**/*.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: true,
+
+    // Concurrency level
+    // how many browser should be started simultaneous
+    concurrency: Infinity
+  })
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "app for health competitions",
   "main": "server.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "karma start",
     "start": "nodemon server/server.js --exec babel-node presets es2015"
   },
   "repository": {
@@ -38,5 +38,11 @@
     "webpack-dev-middleware": "^1.9.0",
     "webpack-dev-server": "^1.16.2",
     "webpack-hot-middleware": "^2.15.0"
+  },
+  "devDependencies": {
+    "jasmine-core": "^2.5.2",
+    "karma": "^1.4.1",
+    "karma-chrome-launcher": "^2.0.0",
+    "karma-jasmine": "^1.1.0"
   }
 }

--- a/test/client/clientSpec.js
+++ b/test/client/clientSpec.js
@@ -1,0 +1,10 @@
+// Just a sample test to check that Karma runs
+
+describe('Test tests', function() {
+
+  it('one should equal 1', function() {
+    var one = 1;
+    expect(one).toEqual(1);
+  });
+
+});


### PR DESCRIPTION
Added Karma testing framework + Jasmine library for use for testing purposes.  Karma and Jasmine were added into dev dependencies in the 'package.json' file, and a new subfolder called 'test' was added under the root.  Within it currently resides a 'client' folder (a folder for 'server' tests can be added as well), and within that is a simple JS file that currently only contains one sample test.

The config file is configured such that 'npm test' can be run from the terminal, and any tests contained within the 'test' folder will be run collectively.