### PR TITLE
(feat) Add basic admin dashboard for manual DB interaction

### DIFF
--- a/public/client/components/Navbar.js
+++ b/public/client/components/Navbar.js
@@ -17,6 +17,7 @@ export default class NavigationBar extends React.Component {
             <NavItem eventKey={1} href="#/user">Profile</NavItem>
             <NavItem eventKey={2} href="#/overview">Overview</NavItem>
             <NavItem eventKey={3} href="#/exercise">Exercise!</NavItem>
+            <NavItem eventKey={4} href="#/admin">Admin Dashboard</NavItem>
           </Nav>
           <Nav pullRight>
             <NavItem eventKey={1} href="#">Logout</NavItem>

--- a/public/client/components/adminDashboard/AddExercise.js
+++ b/public/client/components/adminDashboard/AddExercise.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import axios from 'axios';
+
+
+export default class AddExercise extends React.Component {
+
+  constructor(props) {
+
+    super(props);
+
+    this.state = {};
+
+    this.addExercise = this.addExercise.bind(this);
+  }
+
+  // Manually add an exercise to the database
+  addExercise(e) {
+      e.preventDefault();
+
+      var exObj = {
+        'name': this.refs.name.value,
+        'unit': this.refs.unit.value,
+        'description': this.refs.description.value
+      };
+
+      var context = this;
+
+
+      axios.post('/api/users', exObj)
+      .then(function(res) {
+        console.log('New exercise added!');
+        alert('NewExercise added!');
+        context.refs.name.value = '';
+        context.refs.unit.value = '';
+        context.refs.description.value = '';
+      })
+      .catch(function(err) {
+        console.log(err);
+      });
+
+    }
+
+
+  render() {
+    return (
+        <div className='admin-form'>
+          <p>Add A New Exercise</p>
+          <form className="form" onSubmit={this.addExercise}>
+            <input type="text" name="name" placeholder="Name" ref="name" /><br />
+            <input type="text" name="unit" placeholder="Unit Measure" ref="unit" /><br />
+            <input type="text" name="description" placeholder="Exercise Description" ref="description" /><br />
+            <input type="submit" value="Add Exercise" />
+          </form>
+        </div>
+    )
+  }
+}

--- a/public/client/components/adminDashboard/AddExercise.js
+++ b/public/client/components/adminDashboard/AddExercise.js
@@ -26,7 +26,7 @@ export default class AddExercise extends React.Component {
       var context = this;
 
 
-      axios.post('/api/users', exObj)
+      axios.post('/api/exercises', exObj)
       .then(function(res) {
         console.log('New exercise added!');
         alert('NewExercise added!');

--- a/public/client/components/adminDashboard/AddUser.js
+++ b/public/client/components/adminDashboard/AddUser.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import axios from 'axios';
+
+
+export default class AddUser extends React.Component {
+
+  constructor(props) {
+
+    super(props);
+
+    this.state = {};
+
+    this.addUser = this.addUser.bind(this);
+  }
+
+  // Manually add a user to the database
+  addUser(e) {
+      e.preventDefault();
+
+      var userObj = {
+        'name': this.refs.name.value,
+        'username': this.refs.username.value,
+        'password': this.refs.password.value,
+        'team': this.refs.team.value,
+        'scores': []
+      };
+
+      var context = this;
+
+      // below function will apply appropriate amount of 0 scores to a user if added after-the-fact (i.e. added in week 3, scores = [0, 0, 0])
+      axios.get('/api/rounds').then(function(res) {
+        var roundTotal = res.data.length;
+        for (var i = 1; i <= roundTotal; i++) {
+          userObj.scores.push(0);
+        }
+
+        axios.post('/api/users', userObj)
+        .then(function(res) {
+          console.log('User added!');
+          alert('User added!');
+          context.refs.name.value = '';
+          context.refs.username.value = '';
+          context.refs.password.value = '';
+          context.refs.team.value = '';
+        })
+        .catch(function(err) {
+          console.log(err);
+        });
+
+      });
+    }
+
+
+  render() {
+    return (
+        <div className='admin-form'>
+          <p>Add New User</p>
+          <form className="form" onSubmit={this.addUser}>
+            <input type="text" name="name" placeholder="Name" ref="name" /><br />
+            <input type="text" name="username" placeholder="Username" ref="username" /><br />
+            <input type="text" name="password" placeholder="Password" ref="password" /><br />
+            <input type="text" name="team" placeholder="Team" ref="team" /><br />
+            <input type="submit" value="Add User" />
+          </form>
+        </div>
+    )
+  }
+}

--- a/public/client/components/adminDashboard/Dashboard.js
+++ b/public/client/components/adminDashboard/Dashboard.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import axios from 'axios';
+
+
+export default class Dashboard extends React.Component {
+
+  constructor() {
+
+    super();
+
+    this.state = {};
+  }
+
+  addData(item) {
+    var currentData = this.state.data;
+    currentData.push(item);
+    this.setState({
+      data: currentData
+    });
+  }
+
+  sortByTotal() {
+    var currentData = this.state.data;
+
+    currentData.sort(function(a, b) {
+      return b.total - a.total;
+    });
+
+    this.setState({
+      data: currentData
+    });
+  }
+
+  componentDidMount() {
+    var context = this;
+
+    var users = axios.get('/api/users').then(function(res) {
+      res.data.forEach(function(person) {
+        var total = person.scores.reduce((pv, cv) => pv+cv, 0);
+        person.total = total;
+        context.addData(person);
+      });
+      context.sortByTotal();
+    });
+
+  }
+
+  render() {
+    return (
+      <div id='overview' className='text-center'>
+        <div className='overview-header'>
+          Organization Totals
+        </div>
+        <table className='table'>
+          <tr>
+            <th>Name</th>
+            <th>Team</th>
+            <th>Total</th>
+          </tr>
+          { this.state.data.map((person) =>
+          <UserTotal className='texttd' name={person.name} team={person.team} total={person.total} />
+          ) }
+        </table>
+      </div>
+    )
+  }
+}

--- a/public/client/components/adminDashboard/Dashboard.js
+++ b/public/client/components/adminDashboard/Dashboard.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import axios from 'axios';
+import AddUser from './AddUser.js';
+import AddExercise from './AddExercise.js';
+import NewRound from './NewRound.js';
 
 
 export default class Dashboard extends React.Component {
@@ -9,73 +12,39 @@ export default class Dashboard extends React.Component {
     super();
 
     this.state = {};
-
-    this.addUser = this.addUser.bind(this);
   }
 
-  componentDidMount() {
+  componentWillMount() {
     var context = this;
 
-    // Get all users (for dealing with current user data)
+    // Get existing rounds data
+    axios.get('/api/rounds').then(function(res) {
+      context.setState({rounds: res.data});
+      context.setState({currentRound: res.data[res.data.length - 1].name});
+      context.setState({currentExercise: res.data[res.data.length - 1].exercise});
+      console.log(context.state);
+    });
 
-    // 
-
-
+    // Get existing achievements
+    axios.get('/api/achievements').then(function(res) {
+      context.setState({achievements: res.data});
+      console.log(context.state);
+    });
 
   }
-
-  addUser(e) {
-      e.preventDefault();
-
-      var userObj = {
-        'name': this.refs.name.value,
-        'username': this.refs.username.value,
-        'password': this.refs.password.value,
-        'team': this.refs.team.value,
-        'scores': []
-      };
-
-      // below function will apply appropriate amount of 0 scores to a user if added after-the-fact (i.e. added in week 3, scores = [0, 0, 0])
-      axios.get('/api/rounds').then(function(res) {
-        var roundTotal = res.data.length;
-        for (var i = 1; i <= roundTotal; i++) {
-          userObj.scores.push(0);
-        }
-
-        axios.post('/api/users', userObj)
-        .then(function(res) {
-          console.log(res);
-          console.log('User added!');
-        })
-        .catch(function(err) {
-          console.log(err);
-        });
-
-      });
-
-      this.render();
-
-    }
 
 
   render() {
     return (
       <div id='admin-dashboard' className='text-center'>
         <div className='admin-header'>
-          <h2>Administrator Dashboard<h2>
-          <p>Current Round:</p>
-          <p>Current Exercise:</p>
+          <h2>Administrator Dashboard</h2>
+          <p>Current Round: {this.state.currentRound}</p>
+          <p>Current Exercise: {this.state.currentExercise}</p>
         </div>
-        <div className='add-user'>
-          <p>Temporary Add User Form</p>
-          <form className="form" onSubmit={this.addUser}>
-            <input type="text" name="name" placeholder="Name" ref="name" /><br />
-            <input type="text" name="username" placeholder="Username" ref="username" /><br />
-            <input type="text" name="password" placeholder="Password" ref="password" /><br />
-            <input type="text" name="team" placeholder="Team" ref="team" /><br />
-            <input type="submit" value="Add User" />
-          </form>
-        </div>
+        <NewRound />
+        <AddUser />
+        <AddExercise />
       </div>
     )
   }

--- a/public/client/components/adminDashboard/Dashboard.js
+++ b/public/client/components/adminDashboard/Dashboard.js
@@ -9,59 +9,79 @@ export default class Dashboard extends React.Component {
     super();
 
     this.state = {};
-  }
 
-  addData(item) {
-    var currentData = this.state.data;
-    currentData.push(item);
-    this.setState({
-      data: currentData
-    });
-  }
-
-  sortByTotal() {
-    var currentData = this.state.data;
-
-    currentData.sort(function(a, b) {
-      return b.total - a.total;
-    });
-
-    this.setState({
-      data: currentData
-    });
+    this.addUser = this.addUser.bind(this);
   }
 
   componentDidMount() {
     var context = this;
 
-    var users = axios.get('/api/users').then(function(res) {
-      res.data.forEach(function(person) {
-        var total = person.scores.reduce((pv, cv) => pv+cv, 0);
-        person.total = total;
-        context.addData(person);
-      });
-      context.sortByTotal();
-    });
+    // Get all users (for dealing with current user data)
+
+    // 
+
+
 
   }
 
+  addUser(e) {
+      e.preventDefault();
+
+      var userObj = {
+        'name': this.refs.name.value,
+        'username': this.refs.username.value,
+        'password': this.refs.password.value,
+        'team': this.refs.team.value,
+        'scores': []
+      };
+
+      // below function will apply appropriate amount of 0 scores to a user if added after-the-fact (i.e. added in week 3, scores = [0, 0, 0])
+      axios.get('/api/rounds').then(function(res) {
+        var roundTotal = res.data.length;
+        for (var i = 1; i <= roundTotal; i++) {
+          userObj.scores.push(0);
+        }
+
+        axios.post('/api/users', userObj)
+        .then(function(res) {
+          console.log(res);
+          console.log('User added!');
+        })
+        .catch(function(err) {
+          console.log(err);
+        });
+
+      });
+
+      this.render();
+
+    }
+
+
   render() {
     return (
-      <div id='overview' className='text-center'>
-        <div className='overview-header'>
-          Organization Totals
+      <div id='admin-dashboard' className='text-center'>
+        <div className='admin-header'>
+          <h2>Administrator Dashboard<h2>
+          <p>Current Round:</p>
+          <p>Current Exercise:</p>
         </div>
-        <table className='table'>
-          <tr>
-            <th>Name</th>
-            <th>Team</th>
-            <th>Total</th>
-          </tr>
-          { this.state.data.map((person) =>
-          <UserTotal className='texttd' name={person.name} team={person.team} total={person.total} />
-          ) }
-        </table>
+        <div className='add-user'>
+          <p>Temporary Add User Form</p>
+          <form className="form" onSubmit={this.addUser}>
+            <input type="text" name="name" placeholder="Name" ref="name" /><br />
+            <input type="text" name="username" placeholder="Username" ref="username" /><br />
+            <input type="text" name="password" placeholder="Password" ref="password" /><br />
+            <input type="text" name="team" placeholder="Team" ref="team" /><br />
+            <input type="submit" value="Add User" />
+          </form>
+        </div>
       </div>
     )
   }
 }
+
+
+
+
+        

--- a/public/client/components/adminDashboard/NewRound.js
+++ b/public/client/components/adminDashboard/NewRound.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import axios from 'axios';
+
+
+export default class NewRound extends React.Component {
+
+  constructor() {
+
+    super();
+
+    this.state = {exercises: []};
+
+    this.newRound = this.newRound.bind(this);
+  }
+
+  addData(item) {
+    var currentData = this.state.exercises;
+    currentData.push(item);
+    this.setState({
+      exercises: currentData
+    });
+  }
+
+
+  componentDidMount() {
+    var context = this;
+
+    axios.get('/api/exercises').then(function(res) {
+      res.data.forEach(function(exercise) {
+        context.addData(exercise.name);
+      });
+
+      console.log(context.state);
+    });
+
+  }
+
+
+  // Manually initiate a new round
+  newRound(e) {
+    e.preventDefault();
+
+    var roundObj = {
+      'name': this.refs.name.value,
+      'exercise': this.refs.exercise.value
+    };
+
+    var context = this;
+
+    axios.post('/api/rounds', roundObj)
+    .then(function(res) {
+      console.log('Next round initiated!');
+      alert('Next round initiated!');
+      context.refs.name.value = '';
+      context.refs.exercise.value = '';
+
+      // add a new element to every user's scores array for the new round
+      axios.post('/api/users/newround');
+      console.log('Adding new round score value to all users!');
+    })
+    .catch(function(err) {
+      console.log(err);
+    });
+
+  }
+
+
+  render() {
+    return (
+        <div className='admin-form' id='newround'>
+          <p>Initiate Next Round</p>
+          <form className="form" onSubmit={this.newRound}>
+            Round Name:<br />
+            <input type="text" name="name" placeholder="Round Name" ref="name" /><br />
+            Exercise:<br />
+            <select name="exercise" form='newround' ref="exercise" >
+              { this.state.exercises.map((exercise) =>
+              <option value={exercise.toString()}>{exercise}</option>
+              ) }
+            </select><br />
+            <input type="submit" value="Start Next Round" />
+          </form>
+        </div>
+    )
+  }
+}

--- a/public/client/index.js
+++ b/public/client/index.js
@@ -6,6 +6,7 @@ import App from './components/App';
 import LoggingExercise from './components/exercise/LoggingExercise';
 import UserView from './components/userView/UserView';
 import Overview from './components/overview/Overview';
+import Dashboard from './components/adminDashboard/Dashboard';
   
 render((
   <Router history={hashHistory}>
@@ -13,6 +14,7 @@ render((
       <Route path="/user" component={UserView}/>
       <Route path="/overview" component={Overview}/>
       <Route path="/exercise" component={LoggingExercise}/>
+      <Route path="/admin" component={Dashboard} />
     </Route>
   </Router>
 ), document.getElementById('app'))

--- a/public/client/style.css
+++ b/public/client/style.css
@@ -124,4 +124,7 @@ th {
     color: #fff;
 }
 
+.admin-form {
+  margin-top: 20px;
+}
 

--- a/server/dbmodules/users/userController.js
+++ b/server/dbmodules/users/userController.js
@@ -5,6 +5,7 @@ var findUser = Q.nbind(User.findOne, User);
 var createUser = Q.nbind(User.create, User);
 var findUsers = Q.nbind(User.find, User);
 var findOneAndUpdate = Q.nbind(User.findOneAndUpdate, User);
+var updateUser = Q.nbind(User.update, User);
 
 module.exports = {
 
@@ -57,12 +58,31 @@ module.exports = {
     });
   },
 
+  // Edit a user's scores array
   updateScores: function(req, res, next) {
     return findOneAndUpdate(
       {username: req.params.username},
       {$set: {'scores': req.body.scores}},
       {new: true})
     .then(function(thing) {
+      if (thing) {
+        res.json(thing);
+      }
+      next();
+    }).fail(function(err) {
+      console.log(err);
+      next(err);
+    });
+  },
+
+  // Add a new element to all users' scores array on initiation of a new round
+  addRound: function(req, res, next) {
+    return updateUser(
+      {},
+      { $push: {'scores': 0}},
+      { multi: true })
+    .then(function(thing) {
+      console.log('Updated users scores!');
       if (thing) {
         res.json(thing);
       }

--- a/server/route.js
+++ b/server/route.js
@@ -48,6 +48,9 @@ app.get('/api/users/:username', userController.getUser);
 // Scores array, pre-edit, can be acquired via getting a single user's full data (see above route)
 app.post('/api/users/:username/scores', userController.updateScores);
 
+// Tell DB a new round has started: update all users' scores array
+app.post('/api/users/newround', userController.addRound);
+
 // === ACHIEVEMENT ROUTING ===
 
 // Get all achievements from DB


### PR DESCRIPTION
Created a basic administrator dashboard for manual interaction with the DB. Currently:

- One can manually add a new user by entering a name, username, password, and team.  Submitting will create the user in the database, and they will then be part of what's rendered in the org overview.  By default, they will be set to 'isAdmin: false'.  Also, if a user is added in a round beyond the first, they will be created with the right number of 0's in their "scores" array, so that their scores array reflects the correct round to be logged to.

- One can manually create a new exercise by entering a name, unit measure, and description.  This will save the exercise in the DB to be made available to select when initiating a new round.

- Finally, one can manually initiate the next round by entering a round name (i.e. "Week 3") and selecting from one of the exercises available in the database (from a dropdown).  This will add a new round document in the database, and will instigate adding a new "0" element to every user's "scores" array (to reflect the new round).

Minor margin styling was added to separate the forms on the dashboard.  Further functionality could be added in the future (editing a user's scores, removing users/exercises, etc).